### PR TITLE
Team 43 server side pagination

### DIFF
--- a/backend/sep2025_project_team_004/sep2025_project_team_004/store/urls.py
+++ b/backend/sep2025_project_team_004/sep2025_project_team_004/store/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import ProductListView, ReviewCreateAPIView, CheckoutAndCreateOrderView, AdminOrderListView, MyOrdersView, UpdateOrderStatusView, MyReviewsPaginatedView, ReviewDetailView, ReviewUpdateView
+from .views import ProductListView, ReviewCreateAPIView, CheckoutAndCreateOrderView, AdminOrderListView, MyOrdersPaginatedView, UpdateOrderStatusView, MyReviewsPaginatedView, ReviewDetailView, ReviewUpdateView
 
 app_name = "store" 
 
@@ -8,7 +8,7 @@ urlpatterns = [
     path('reviews/', ReviewCreateAPIView.as_view(), name='review-create'),
     path("orders/create/", CheckoutAndCreateOrderView.as_view(), name="create-order"),
     path("orders/admin/", AdminOrderListView.as_view(), name="orders-admin"),
-    path("orders/my/", MyOrdersView.as_view(), name="my-orders"),
+    path("orders/my/", MyOrdersPaginatedView.as_view(), name="my-orders"),
     path("orders/update/<int:order_id>/", UpdateOrderStatusView.as_view(), name="update-order"),
     path('reviews/my/', MyReviewsPaginatedView.as_view(), name='my-reviews'),
     path('reviews/<int:pk>/', ReviewDetailView.as_view(), name='review-detail'),

--- a/backend/sep2025_project_team_004/sep2025_project_team_004/store/urls.py
+++ b/backend/sep2025_project_team_004/sep2025_project_team_004/store/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import ProductListView, ReviewCreateAPIView, CheckoutAndCreateOrderView, AdminOrderListView, MyOrdersView, UpdateOrderStatusView, MyReviewsView, ReviewDetailView, ReviewUpdateView
+from .views import ProductListView, ReviewCreateAPIView, CheckoutAndCreateOrderView, AdminOrderListView, MyOrdersView, UpdateOrderStatusView, MyReviewsPaginatedView, ReviewDetailView, ReviewUpdateView
 
 app_name = "store" 
 
@@ -10,7 +10,7 @@ urlpatterns = [
     path("orders/admin/", AdminOrderListView.as_view(), name="orders-admin"),
     path("orders/my/", MyOrdersView.as_view(), name="my-orders"),
     path("orders/update/<int:order_id>/", UpdateOrderStatusView.as_view(), name="update-order"),
-    path('reviews/my/', MyReviewsView.as_view(), name='my-reviews'),
+    path('reviews/my/', MyReviewsPaginatedView.as_view(), name='my-reviews'),
     path('reviews/<int:pk>/', ReviewDetailView.as_view(), name='review-detail'),
     path('reviews/<int:pk>/update/', ReviewUpdateView.as_view(), name='review-update'),
 ]

--- a/backend/sep2025_project_team_004/sep2025_project_team_004/store/views.py
+++ b/backend/sep2025_project_team_004/sep2025_project_team_004/store/views.py
@@ -4,7 +4,8 @@ from .serializers import ProductSerializer, OrderSerializer, ReviewSerializer
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework.generics import RetrieveUpdateAPIView
+from rest_framework.generics import RetrieveUpdateAPIView, ListAPIView
+from rest_framework.pagination import PageNumberPagination
 from rest_framework import status
 from .models import Order
 
@@ -105,14 +106,17 @@ class UpdateOrderStatusView(APIView):
             return Response(OrderSerializer(order).data)
         except Order.DoesNotExist:
             return Response({"error": "Order not found"}, status=404)
+        
+class ReviewPagination(PageNumberPagination):
+    page_size = 5
 
-class MyReviewsView(APIView):
+class MyReviewsPaginatedView(ListAPIView):
+    serializer_class = ReviewSerializer
     permission_classes = [IsAuthenticated]
+    pagination_class = ReviewPagination
 
-    def get(self, request):
-        reviews = Review.objects.filter(user=request.user).select_related("product")
-        serializer = ReviewSerializer(reviews, many=True)
-        return Response(serializer.data)
+    def get_queryset(self):
+        return Review.objects.filter(user=self.request.user).order_by('-created_at')
     
 class ReviewDetailView(APIView):
     permission_classes = [IsAuthenticated]

--- a/backend/sep2025_project_team_004/sep2025_project_team_004/store/views.py
+++ b/backend/sep2025_project_team_004/sep2025_project_team_004/store/views.py
@@ -83,13 +83,16 @@ class AdminOrderListView(APIView):
         return Response(serializer.data)
 
 
-class MyOrdersView(APIView):
-    permission_classes = [IsAuthenticated]
+class OrderPagination(PageNumberPagination):
+    page_size = 5
 
-    def get(self, request):
-        orders = Order.objects.filter(user=request.user).prefetch_related("items")
-        serializer = OrderSerializer(orders, many=True)
-        return Response(serializer.data)
+class MyOrdersPaginatedView(ListAPIView):
+    serializer_class = OrderSerializer
+    permission_classes = [IsAuthenticated]
+    pagination_class = OrderPagination
+
+    def get_queryset(self):
+        return Order.objects.filter(user=self.request.user).prefetch_related("items").order_by('-created_at')
     
 class UpdateOrderStatusView(APIView):
     permission_classes = [IsAuthenticated]


### PR DESCRIPTION
## 📝 Summary 

Added server side pagination for orders, admin orders, and reviews

## 🔗 Related Issues 

- Closes Team 43 server side pagination

## ✨ Changes 

- [ ] **Change 1**: Changed store views.py to account for server side pagination

- [ ] **Change 2**: Changed frontend to account for pagination

## 🚀 Implementation Details 

- On other people's projects, they have numbers at the bottom of the screen to account for the pages. In my implementation, as you scroll close to the bottom of the screen, it loads more instances of data. I think this looks cleaner for our purposes, but it wont be hard to change if we want to do the numbered pages at the bottom

## ✅ Checklist

✅My code follows the project's coding style guidelines.

✅I have tested this change locally and verified it works as expected.

✅I have updated any necessary documentation.

✅I have added necessary unit/integration tests (if applicable).

✅No new errors or warnings in the console.

✅Code Coverage is at least 80%
